### PR TITLE
add additional frontend tests

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
+
+jest.mock("./AppContent.jsx", () => {
+  return function DummyAppContent() {
+    return <div data-testid="app-content">App Content</div>;
+  };
+});
+
+describe("App", () => {
+  test("renders AppContent wrapped with AuthProvider and Router", () => {
+    render(<App />);
+    const appContentElement = screen.getByTestId("app-content");
+    expect(appContentElement).toBeInTheDocument();
+    expect(appContentElement).toHaveTextContent("App Content");
+  });
+});

--- a/frontend/src/contexts/AuthContext.test.jsx
+++ b/frontend/src/contexts/AuthContext.test.jsx
@@ -1,0 +1,133 @@
+import React, { useContext } from "react";
+import { render, waitFor, act } from "@testing-library/react";
+import AuthContext, { AuthProvider } from "./AuthContext";
+
+// A simple consumer component to read and display context values
+const DummyConsumer = () => {
+  const { isAuthenticated, username, hasProfile, csrfToken, login, logout } =
+    useContext(AuthContext);
+  return (
+    <div data-testid="auth-values">
+      <span data-testid="isAuthenticated">
+        {isAuthenticated ? "true" : "false"}
+      </span>
+      <span data-testid="username">{username}</span>
+      <span data-testid="hasProfile">{hasProfile ? "true" : "false"}</span>
+      <span data-testid="csrfToken">{csrfToken}</span>
+      <button data-testid="login" onClick={() => login("testuser", true)}>
+        Login
+      </button>
+      <button data-testid="logout" onClick={logout}>
+        Logout
+      </button>
+    </div>
+  );
+};
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    jest.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("fetches auth status and csrf token on mount", async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ username: "user1", hasProfile: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "abc123" }),
+      });
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <DummyConsumer />
+      </AuthProvider>
+    );
+
+    // Wait until the asynchronous useEffect has updated the state
+    await waitFor(() =>
+      expect(getByTestId("isAuthenticated").textContent).toBe("true")
+    );
+    expect(getByTestId("username").textContent).toBe("user1");
+    expect(getByTestId("hasProfile").textContent).toBe("true");
+    expect(getByTestId("csrfToken").textContent).toBe("abc123");
+  });
+
+  test("login updates state", async () => {
+    // Simulate the initial fetch calls resulting in a "not authenticated" state.
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: false, // simulate check-auth failure
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "initToken" }),
+      });
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <DummyConsumer />
+      </AuthProvider>
+    );
+
+    // Wait until the initial fetch calls complete; we expect not authenticated
+    await waitFor(() =>
+      expect(getByTestId("isAuthenticated").textContent).toBe("false")
+    );
+
+    // Simulate a login
+    act(() => {
+      getByTestId("login").click();
+    });
+
+    expect(getByTestId("isAuthenticated").textContent).toBe("true");
+    expect(getByTestId("username").textContent).toBe("testuser");
+    expect(getByTestId("hasProfile").textContent).toBe("true");
+  });
+
+  test("logout resets state on successful logout", async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ username: "user1", hasProfile: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "abc123" }),
+      });
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <DummyConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("isAuthenticated").textContent).toBe("true")
+    );
+
+    // mock the logout fetch call
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    await act(async () => {
+      getByTestId("logout").click();
+    });
+
+    // Wait until the state is reset.
+    await waitFor(() =>
+      expect(getByTestId("isAuthenticated").textContent).toBe("false")
+    );
+    expect(getByTestId("username").textContent).toBe("");
+    expect(getByTestId("hasProfile").textContent).toBe("false");
+  });
+});


### PR DESCRIPTION
This pull request introduces new unit tests for the `App` component and the `AuthContext` context provider to ensure their proper functionality. The most important changes include adding a mock for `AppContent` within the `App` component tests and creating comprehensive tests for the `AuthProvider` to verify authentication state management.

### Unit Tests for `App` Component:
* [`frontend/src/App.test.jsx`](diffhunk://#diff-2ccc37030356220d658556364087e1aa36d12837f4d954b1e80185c6f5b7151aR1-R18): Added tests to verify that `AppContent` is correctly wrapped with `AuthProvider` and `Router`, using a mock for `AppContent`.

### Unit Tests for `AuthContext`:
* [`frontend/src/contexts/AuthContext.test.jsx`](diffhunk://#diff-64821838aceacd7ab41dd01813bc7d08b5f2c0a00f5ea92fe544259aef2da69aR1-R133): Added tests to ensure that `AuthProvider` correctly fetches authentication status and CSRF token on mount, updates state on login, and resets state on logout.